### PR TITLE
Persisting User ID from Vercel CLI

### DIFF
--- a/hooks/session-start-profiler.mjs
+++ b/hooks/session-start-profiler.mjs
@@ -7,6 +7,7 @@ import {
   readdirSync,
   writeFileSync
 } from "fs";
+import { homedir } from "os";
 import { delimiter, join, resolve } from "path";
 import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
@@ -297,6 +298,51 @@ function checkVercelCli() {
   const needsUpdate = versionComparison === null ? !!(currentVersion && latestVersion && currentVersion !== latestVersion) : versionComparison < 0;
   return { installed: true, currentVersion, latestVersion, needsUpdate };
 }
+function getVercelCliDataDirs(env = process.env, homeDir = homedir()) {
+  const directories = [];
+  if (process.platform === "darwin") {
+    directories.push(join(homeDir, "Library", "Application Support", "com.vercel.cli"));
+    directories.push(join(homeDir, "Library", "Application Support", "now"));
+  } else if (process.platform === "win32") {
+    if (typeof env.APPDATA === "string" && env.APPDATA.trim() !== "") {
+      directories.push(join(env.APPDATA, "com.vercel.cli"));
+      directories.push(join(env.APPDATA, "now"));
+    }
+  } else {
+    const xdgDataHome = typeof env.XDG_DATA_HOME === "string" && env.XDG_DATA_HOME.trim() !== "" ? env.XDG_DATA_HOME : join(homeDir, ".local", "share");
+    directories.push(join(xdgDataHome, "com.vercel.cli"));
+    directories.push(join(xdgDataHome, "now"));
+  }
+  directories.push(join(homeDir, ".now"));
+  return [...new Set(directories)];
+}
+function readPersistedVercelCliUserId(env = process.env, homeDir = homedir()) {
+  for (const configDir of getVercelCliDataDirs(env, homeDir)) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(configDir, "auth.json"), "utf8"));
+      if (typeof parsed.userId === "string" && parsed.userId.trim() !== "") {
+        return parsed.userId;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+function buildSessionStartTelemetryEntries(args) {
+  const entries = [
+    { key: "session:device_id", value: args.deviceId },
+    { key: "session:platform", value: process.platform },
+    { key: "session:likely_skills", value: args.likelySkills.join(",") },
+    { key: "session:greenfield", value: String(args.greenfield) },
+    { key: "session:vercel_cli_installed", value: String(args.cliStatus.installed) },
+    { key: "session:vercel_cli_version", value: args.cliStatus.currentVersion || "" }
+  ];
+  if (args.cliStatus.installed && args.vercelCliUserId) {
+    entries.push({ key: "session:vercel_cli_user_id", value: args.vercelCliUserId });
+  }
+  return entries;
+}
 function parseSessionStartInput(raw) {
   try {
     if (!raw.trim()) return null;
@@ -470,14 +516,14 @@ async function main() {
   }
   if (sessionId) {
     const deviceId = getOrCreateDeviceId();
-    await trackBaseEvents(sessionId, [
-      { key: "session:device_id", value: deviceId },
-      { key: "session:platform", value: process.platform },
-      { key: "session:likely_skills", value: likelySkills.join(",") },
-      { key: "session:greenfield", value: String(greenfield !== null) },
-      { key: "session:vercel_cli_installed", value: String(cliStatus.installed) },
-      { key: "session:vercel_cli_version", value: cliStatus.currentVersion || "" }
-    ]).catch(() => {
+    const vercelCliUserId = cliStatus.installed ? readPersistedVercelCliUserId() : null;
+    await trackBaseEvents(sessionId, buildSessionStartTelemetryEntries({
+      deviceId,
+      likelySkills,
+      greenfield: greenfield !== null,
+      cliStatus,
+      vercelCliUserId
+    })).catch(() => {
     });
   }
   if (cursorOutput) {
@@ -493,6 +539,7 @@ if (isSessionStartProfilerEntrypoint) {
 export {
   buildSessionStartProfilerEnvVars,
   buildSessionStartProfilerUserMessages,
+  buildSessionStartTelemetryEntries,
   checkGreenfield,
   detectSessionStartPlatform,
   formatSessionStartProfilerCursorOutput,
@@ -501,5 +548,6 @@ export {
   parseSessionStartInput,
   profileBootstrapSignals,
   profileProject,
+  readPersistedVercelCliUserId,
   resolveSessionStartProjectRoot
 };

--- a/hooks/session-start-profiler.mjs
+++ b/hooks/session-start-profiler.mjs
@@ -19,7 +19,7 @@ import {
 import { pluginRoot, profileCachePath, safeReadJson, writeSessionFile } from "./hook-env.mjs";
 import { createLogger, logCaughtError } from "./logger.mjs";
 import { buildSkillMap } from "./skill-map-frontmatter.mjs";
-import { trackBaseEvents, getOrCreateDeviceId } from "./telemetry.mjs";
+import { trackBaseEvents, getOrCreateDeviceId, isUserIdTelemetryEnabled } from "./telemetry.mjs";
 var FILE_MARKERS = [
   { file: "next.config.js", skills: ["nextjs", "turbopack"] },
   { file: "next.config.mjs", skills: ["nextjs", "turbopack"] },
@@ -516,7 +516,7 @@ async function main() {
   }
   if (sessionId) {
     const deviceId = getOrCreateDeviceId();
-    const vercelCliUserId = cliStatus.installed ? readPersistedVercelCliUserId() : null;
+    const vercelCliUserId = cliStatus.installed && isUserIdTelemetryEnabled() ? readPersistedVercelCliUserId() : null;
     await trackBaseEvents(sessionId, buildSessionStartTelemetryEntries({
       deviceId,
       likelySkills,

--- a/hooks/src/session-start-profiler.mts
+++ b/hooks/src/session-start-profiler.mts
@@ -312,6 +312,10 @@ interface VercelCliStatus {
   needsUpdate: boolean;
 }
 
+interface VercelCliAuthConfig {
+  userId?: unknown;
+}
+
 // Subprocess args kept as constants to avoid array literals that confuse the
 // validate.ts slug-extraction regex (it scans for `["..."]` patterns).
 const VERCEL_VERSION_ARGS: string[] = "--version".split(" ");
@@ -454,6 +458,74 @@ function checkVercelCli(): VercelCliStatus {
     : versionComparison < 0;
 
   return { installed: true, currentVersion, latestVersion, needsUpdate };
+}
+
+function getVercelCliDataDirs(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir(),
+): string[] {
+  const directories: string[] = [];
+
+  if (process.platform === "darwin") {
+    directories.push(join(homeDir, "Library", "Application Support", "com.vercel.cli"));
+    directories.push(join(homeDir, "Library", "Application Support", "now"));
+  } else if (process.platform === "win32") {
+    if (typeof env.APPDATA === "string" && env.APPDATA.trim() !== "") {
+      directories.push(join(env.APPDATA, "com.vercel.cli"));
+      directories.push(join(env.APPDATA, "now"));
+    }
+  } else {
+    const xdgDataHome = typeof env.XDG_DATA_HOME === "string" && env.XDG_DATA_HOME.trim() !== ""
+      ? env.XDG_DATA_HOME
+      : join(homeDir, ".local", "share");
+    directories.push(join(xdgDataHome, "com.vercel.cli"));
+    directories.push(join(xdgDataHome, "now"));
+  }
+
+  directories.push(join(homeDir, ".now"));
+
+  return [...new Set(directories)];
+}
+
+export function readPersistedVercelCliUserId(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir(),
+): string | null {
+  for (const configDir of getVercelCliDataDirs(env, homeDir)) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(configDir, "auth.json"), "utf8")) as VercelCliAuthConfig;
+      if (typeof parsed.userId === "string" && parsed.userId.trim() !== "") {
+        return parsed.userId;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function buildSessionStartTelemetryEntries(args: {
+  deviceId: string;
+  likelySkills: string[];
+  greenfield: boolean;
+  cliStatus: VercelCliStatus;
+  vercelCliUserId?: string | null;
+}): Array<{ key: string; value: string }> {
+  const entries = [
+    { key: "session:device_id", value: args.deviceId },
+    { key: "session:platform", value: process.platform },
+    { key: "session:likely_skills", value: args.likelySkills.join(",") },
+    { key: "session:greenfield", value: String(args.greenfield) },
+    { key: "session:vercel_cli_installed", value: String(args.cliStatus.installed) },
+    { key: "session:vercel_cli_version", value: args.cliStatus.currentVersion || "" },
+  ];
+
+  if (args.cliStatus.installed && args.vercelCliUserId) {
+    entries.push({ key: "session:vercel_cli_user_id", value: args.vercelCliUserId });
+  }
+
+  return entries;
 }
 
 // ---------------------------------------------------------------------------
@@ -699,14 +771,14 @@ async function main(): Promise<void> {
   // Base telemetry — enabled by default unless VERCEL_PLUGIN_TELEMETRY=off
   if (sessionId) {
     const deviceId = getOrCreateDeviceId();
-    await trackBaseEvents(sessionId, [
-      { key: "session:device_id", value: deviceId },
-      { key: "session:platform", value: process.platform },
-      { key: "session:likely_skills", value: likelySkills.join(",") },
-      { key: "session:greenfield", value: String(greenfield !== null) },
-      { key: "session:vercel_cli_installed", value: String(cliStatus.installed) },
-      { key: "session:vercel_cli_version", value: cliStatus.currentVersion || "" },
-    ]).catch(() => {});
+    const vercelCliUserId = cliStatus.installed ? readPersistedVercelCliUserId() : null;
+    await trackBaseEvents(sessionId, buildSessionStartTelemetryEntries({
+      deviceId,
+      likelySkills,
+      greenfield: greenfield !== null,
+      cliStatus,
+      vercelCliUserId,
+    })).catch(() => {});
   }
 
   if (cursorOutput) {

--- a/hooks/src/session-start-profiler.mts
+++ b/hooks/src/session-start-profiler.mts
@@ -32,7 +32,7 @@ import {
 import { pluginRoot, profileCachePath, safeReadJson, writeSessionFile } from "./hook-env.mjs";
 import { createLogger, logCaughtError, type Logger } from "./logger.mjs";
 import { buildSkillMap } from "./skill-map-frontmatter.mjs";
-import { trackBaseEvents, getOrCreateDeviceId } from "./telemetry.mjs";
+import { trackBaseEvents, getOrCreateDeviceId, isUserIdTelemetryEnabled } from "./telemetry.mjs";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -771,7 +771,9 @@ async function main(): Promise<void> {
   // Base telemetry — enabled by default unless VERCEL_PLUGIN_TELEMETRY=off
   if (sessionId) {
     const deviceId = getOrCreateDeviceId();
-    const vercelCliUserId = cliStatus.installed ? readPersistedVercelCliUserId() : null;
+    const vercelCliUserId = cliStatus.installed && isUserIdTelemetryEnabled()
+      ? readPersistedVercelCliUserId()
+      : null;
     await trackBaseEvents(sessionId, buildSessionStartTelemetryEntries({
       deviceId,
       likelySkills,

--- a/hooks/src/telemetry.mts
+++ b/hooks/src/telemetry.mts
@@ -115,6 +115,24 @@ export function isPromptTelemetryEnabled(env: NodeJS.ProcessEnv = process.env): 
   }
 }
 
+/**
+ * Account-linked telemetry is allowed unless the user has opted out.
+ * A global telemetry override disables it entirely, and an explicit
+ * "disabled" preference blocks persisted Vercel CLI user identifiers.
+ */
+export function isUserIdTelemetryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const override = getTelemetryOverride(env);
+  if (override === "off") return false;
+
+  try {
+    const prefPath = join(homedir(), ".claude", "vercel-plugin-telemetry-preference");
+    const pref = readFileSync(prefPath, "utf-8").trim();
+    return pref !== "disabled";
+  } catch {
+    return true;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Always-on base telemetry (session, tool, skill injection events)
 // ---------------------------------------------------------------------------

--- a/hooks/telemetry.mjs
+++ b/hooks/telemetry.mjs
@@ -68,6 +68,17 @@ function isPromptTelemetryEnabled(env = process.env) {
     return false;
   }
 }
+function isUserIdTelemetryEnabled(env = process.env) {
+  const override = getTelemetryOverride(env);
+  if (override === "off") return false;
+  try {
+    const prefPath = join(homedir(), ".claude", "vercel-plugin-telemetry-preference");
+    const pref = readFileSync(prefPath, "utf-8").trim();
+    return pref !== "disabled";
+  } catch {
+    return true;
+  }
+}
 async function trackBaseEvent(sessionId, key, value) {
   if (!isBaseTelemetryEnabled()) return;
   const event = {
@@ -115,6 +126,7 @@ export {
   getTelemetryOverride,
   isBaseTelemetryEnabled,
   isPromptTelemetryEnabled,
+  isUserIdTelemetryEnabled,
   trackBaseEvent,
   trackBaseEvents,
   trackEvent,

--- a/tests/session-start-profiler.test.ts
+++ b/tests/session-start-profiler.test.ts
@@ -784,6 +784,80 @@ describe("profileProject (unit)", () => {
   });
 });
 
+describe("session-start telemetry helpers (unit)", () => {
+  test("reads persisted Vercel CLI userId from auth.json", async () => {
+    const { readPersistedVercelCliUserId } = await import("../hooks/session-start-profiler.mjs");
+    const homeDir = join(tempDir, "home");
+    const env: Record<string, string> = {};
+    const authDir = process.platform === "win32"
+      ? (() => {
+        const appData = join(homeDir, "AppData", "Roaming");
+        env.APPDATA = appData;
+        return join(appData, "com.vercel.cli");
+      })()
+      : process.platform === "darwin"
+      ? join(homeDir, "Library", "Application Support", "com.vercel.cli")
+      : (() => {
+        const xdgDataHome = join(homeDir, ".local", "share");
+        env.XDG_DATA_HOME = xdgDataHome;
+        return join(xdgDataHome, "com.vercel.cli");
+      })();
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(
+      join(authDir, "auth.json"),
+      JSON.stringify({ token: "redacted", userId: "user_123" }),
+      "utf-8",
+    );
+
+    expect(readPersistedVercelCliUserId(env, homeDir)).toBe("user_123");
+  });
+
+  test("includes Vercel CLI userId in session telemetry only when present", async () => {
+    const { buildSessionStartTelemetryEntries } = await import("../hooks/session-start-profiler.mjs");
+
+    const withUserId = buildSessionStartTelemetryEntries({
+      deviceId: "device_123",
+      likelySkills: ["nextjs", "vercel-cli"],
+      greenfield: false,
+      cliStatus: {
+        installed: true,
+        currentVersion: "44.7.3",
+        needsUpdate: false,
+      },
+      vercelCliUserId: "user_123",
+    });
+    expect(withUserId).toContainEqual({
+      key: "session:vercel_cli_user_id",
+      value: "user_123",
+    });
+
+    const withoutUserId = buildSessionStartTelemetryEntries({
+      deviceId: "device_123",
+      likelySkills: ["nextjs", "vercel-cli"],
+      greenfield: false,
+      cliStatus: {
+        installed: true,
+        currentVersion: "44.7.3",
+        needsUpdate: false,
+      },
+      vercelCliUserId: null,
+    });
+    expect(withoutUserId.find((entry) => entry.key === "session:vercel_cli_user_id")).toBeUndefined();
+
+    const cliMissing = buildSessionStartTelemetryEntries({
+      deviceId: "device_123",
+      likelySkills: ["nextjs"],
+      greenfield: false,
+      cliStatus: {
+        installed: false,
+        needsUpdate: false,
+      },
+      vercelCliUserId: "user_123",
+    });
+    expect(cliMissing.find((entry) => entry.key === "session:vercel_cli_user_id")).toBeUndefined();
+  });
+});
+
 describe("logBrokenSkillFrontmatterSummary (unit)", () => {
   test("emits one summary warning when a skill has malformed frontmatter", async () => {
     const { logBrokenSkillFrontmatterSummary } = await import("../hooks/session-start-profiler.mjs");

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -12,8 +12,8 @@ let tempHome: string;
 
 async function runTelemetryProbe(options: {
   telemetryEnv?: string;
-  preference?: "enabled" | "disabled";
-}): Promise<{ baseEnabled: boolean; promptEnabled: boolean; calls: number }> {
+  preference?: "enabled" | "disabled" | "asked";
+}): Promise<{ baseEnabled: boolean; promptEnabled: boolean; userIdEnabled: boolean; calls: number }> {
   const mergedEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
     HOME: tempHome,
@@ -45,10 +45,11 @@ async function runTelemetryProbe(options: {
 
     const baseEnabled = telemetry.isBaseTelemetryEnabled();
     const promptEnabled = telemetry.isPromptTelemetryEnabled();
+    const userIdEnabled = telemetry.isUserIdTelemetryEnabled();
     await telemetry.trackBaseEvents("session", [{ key: "session:platform", value: "darwin" }]);
     await telemetry.trackEvents("session", [{ key: "prompt:text", value: "hello from prompt" }]);
 
-    console.log(JSON.stringify({ baseEnabled, promptEnabled, calls }));
+    console.log(JSON.stringify({ baseEnabled, promptEnabled, userIdEnabled, calls }));
   `;
 
   const proc = Bun.spawn([NODE_BIN, "--input-type=module", "-e", script], {
@@ -65,7 +66,7 @@ async function runTelemetryProbe(options: {
     throw new Error(stderr || `telemetry probe exited with code ${code}`);
   }
 
-  return JSON.parse(stdout.trim()) as { baseEnabled: boolean; promptEnabled: boolean; calls: number };
+  return JSON.parse(stdout.trim()) as { baseEnabled: boolean; promptEnabled: boolean; userIdEnabled: boolean; calls: number };
 }
 
 async function runPromptHook(env: Record<string, string | undefined>): Promise<{ code: number; stdout: string; stderr: string }> {
@@ -113,14 +114,32 @@ describe("telemetry controls", () => {
     const result = await runTelemetryProbe({ telemetryEnv: "off" });
     expect(result.baseEnabled).toBe(false);
     expect(result.promptEnabled).toBe(false);
+    expect(result.userIdEnabled).toBe(false);
     expect(result.calls).toBe(0);
   });
 
-  test("disabled preference blocks prompt text but not default base telemetry", async () => {
+  test("asked preference still allows user-id telemetry while prompt telemetry stays opt-in", async () => {
+    const result = await runTelemetryProbe({ preference: "asked" });
+    expect(result.baseEnabled).toBe(true);
+    expect(result.promptEnabled).toBe(false);
+    expect(result.userIdEnabled).toBe(true);
+    expect(result.calls).toBe(1);
+  });
+
+  test("disabled preference blocks prompt text and user-id telemetry but not default base telemetry", async () => {
     const result = await runTelemetryProbe({ preference: "disabled" });
     expect(result.baseEnabled).toBe(true);
     expect(result.promptEnabled).toBe(false);
+    expect(result.userIdEnabled).toBe(false);
     expect(result.calls).toBe(1);
+  });
+
+  test("enabled preference allows prompt text and user-id telemetry", async () => {
+    const result = await runTelemetryProbe({ preference: "enabled" });
+    expect(result.baseEnabled).toBe(true);
+    expect(result.promptEnabled).toBe(true);
+    expect(result.userIdEnabled).toBe(true);
+    expect(result.calls).toBe(2);
   });
 
   test("prompt hook does not ask for telemetry when VERCEL_PLUGIN_TELEMETRY=off", async () => {


### PR DESCRIPTION
This adds if a user is opt-in and a confirmed user of the vercel cli we pass their vercel user id into the plugin telemetry. 
opt-out fully removes this. 