### PR TITLE
fix(ai-gateway): anchor model-slug regex to prevent false positives

### DIFF
--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-11T21:14:22.790Z",
+  "generatedAt": "2026-04-14T02:14:44.931Z",
   "version": 2,
   "skills": {
     "vercel-agent": {
@@ -969,7 +969,7 @@
       ],
       "validate": [
         {
-          "pattern": "\\d+-\\d+[)'\"]",
+          "pattern": "\\b(claude|gpt|gemini|llama|mistral|qwen|deepseek)[a-z0-9-]*-\\d+-\\d+[a-z0-9-]*\\b",
           "message": "Model slug uses hyphens — use dots not hyphens for version numbers (e.g., claude-sonnet-4.6)",
           "severity": "error"
         },

--- a/skills/ai-gateway/SKILL.md
+++ b/skills/ai-gateway/SKILL.md
@@ -19,7 +19,7 @@ metadata:
     - '\byarn\s+add\s+[^\n]*@ai-sdk/gateway\b'
 validate:
   -
-    pattern: \d+-\d+[)'"]
+    pattern: '\b(claude|gpt|gemini|llama|mistral|qwen|deepseek)[a-z0-9-]*-\d+-\d+[a-z0-9-]*\b'
     message: 'Model slug uses hyphens — use dots not hyphens for version numbers (e.g., claude-sonnet-4.6)'
     severity: error
   -


### PR DESCRIPTION
## Problem

The `Model slug uses hyphens` validator rule in `skills/ai-gateway/SKILL.md` (line 22) uses `\d+-\d+[)'"]` — any digit-hyphen-digit followed by `)`, `'`, or `"`. This is much broader than the intended error class (hyphenated model version slugs like `"claude-sonnet-4-5"`), producing false-positive errors in agent tooling whenever those characters coincide.

Examples triggered in real usage against unrelated docs/code:

| Content | Erroneous match |
|---|---|
| `(line 13-21):` (markdown line-range) | `13-21)` |
| `"00000000-0000-0000-..."` (UUID string literal) | `0-0"` |
| `"192.168.1.1-2"` (IP range) | `1-2"` |
| `"1-2"` (semver pair) | `1-2"` |

## Fix

Anchor the pattern on known model-family keywords with `\b` word boundaries, matching the convention already used by other patterns in the same file (e.g., `bashPatterns` on line 15: `\bvercel\s+env\s+pull\b`).

```
\b(claude|gpt|gemini|llama|mistral|qwen|deepseek)[a-z0-9-]*-\d+-\d+[a-z0-9-]*\b
```

## Verification

Tested against both intended targets and known false-positive cases:

| Input | Matches? | Note |
|---|---|---|
| `claude-sonnet-4-5` | ✓ | intended target |
| `"claude-sonnet-4-5-20250514"` | ✓ | full model ID |
| `"anthropic/claude-sonnet-4-5"` | ✓ | provider-prefixed slug |
| `"openai/gpt-5-4"` | ✓ | gpt variant |
| `(line 13-21):` | ✗ | line range (was FP) |
| `"00000000-0000-0000-..."` | ✗ | UUID (was FP) |
| `claude-sonnet-4.6` | ✗ | correct dot form, no warning |
| `1-2` (semver pair) | ✗ | no keyword, skipped |
| `192.168.1.1-2` (IP) | ✗ | no keyword, skipped |

## Files

- `skills/ai-gateway/SKILL.md` — regex change
- `generated/skill-manifest.json` — regenerated via `bun run build:manifest`