### PR TITLE
feat(vercel-storage): inline marketplace install flow

### DIFF
--- a/generated/build-from-skills.manifest.json
+++ b/generated/build-from-skills.manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-11T21:14:22.852Z",
+  "generatedAt": "2026-04-24T23:38:20.694Z",
   "templates": [
     {
       "template": "agents/ai-architect.md.tmpl",

--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-14T02:14:44.931Z",
+  "generatedAt": "2026-04-24T23:50:09.258Z",
   "version": 2,
   "skills": {
     "vercel-agent": {
@@ -277,7 +277,17 @@
         "lib/supabase.*",
         "src/lib/supabase.*",
         "prisma/schema.prisma",
-        "prisma/**"
+        "prisma/**",
+        "lib/db/**",
+        "src/lib/db/**",
+        "lib/db.*",
+        "src/lib/db.*",
+        "src/db/**",
+        "src/db.*",
+        "server/db/**",
+        "server/db.*",
+        "src/server/db/**",
+        "src/server/db.*"
       ],
       "bashPatterns": [
         "\\bnpm\\s+(install|i|add)\\s+[^\\n]*@vercel/blob\\b",
@@ -355,7 +365,17 @@
         "^lib\\/supabase\\.[^/]*$",
         "^src\\/lib\\/supabase\\.[^/]*$",
         "^prisma\\/schema\\.prisma$",
-        "^prisma\\/.*$"
+        "^prisma\\/.*$",
+        "^lib\\/db\\/.*$",
+        "^src\\/lib\\/db\\/.*$",
+        "^lib\\/db\\.[^/]*$",
+        "^src\\/lib\\/db\\.[^/]*$",
+        "^src\\/db\\/.*$",
+        "^src\\/db\\.[^/]*$",
+        "^server\\/db\\/.*$",
+        "^server\\/db\\.[^/]*$",
+        "^src\\/server\\/db\\/.*$",
+        "^src\\/server\\/db\\.[^/]*$"
       ],
       "bashRegexSources": [
         "\\bnpm\\s+(install|i|add)\\s+[^\\n]*@vercel/blob\\b",
@@ -525,6 +545,68 @@
           "skipIfFileContains": "@clerk/|@auth0/|@descope/"
         }
       ],
+      "promptSignals": {
+        "phrases": [
+          "add a database",
+          "set up a database",
+          "need a database",
+          "add postgres",
+          "set up postgres",
+          "add redis",
+          "persist data",
+          "save todos",
+          "persist todos",
+          "store todos",
+          "where do I store"
+        ],
+        "allOf": [
+          [
+            "add",
+            "database"
+          ],
+          [
+            "set",
+            "up",
+            "database"
+          ],
+          [
+            "need",
+            "database"
+          ],
+          [
+            "store",
+            "users"
+          ],
+          [
+            "save",
+            "users"
+          ],
+          [
+            "persist",
+            "users"
+          ],
+          [
+            "upload",
+            "files"
+          ],
+          [
+            "store",
+            "images"
+          ]
+        ],
+        "anyOf": [
+          "database",
+          "postgres",
+          "neon",
+          "upstash",
+          "redis",
+          "blob storage",
+          "drizzle",
+          "prisma"
+        ],
+        "noneOf": [],
+        "minScore": 6
+      },
       "retrieval": {
         "aliases": [
           "database",

--- a/skills/vercel-storage/SKILL.md
+++ b/skills/vercel-storage/SKILL.md
@@ -22,6 +22,16 @@ metadata:
     - 'src/lib/supabase.*'
     - 'prisma/schema.prisma'
     - 'prisma/**'
+    - 'lib/db/**'
+    - 'src/lib/db/**'
+    - 'lib/db.*'
+    - 'src/lib/db.*'
+    - 'src/db/**'
+    - 'src/db.*'
+    - 'server/db/**'
+    - 'server/db.*'
+    - 'src/server/db/**'
+    - 'src/server/db.*'
   bashPatterns:
     - '\bnpm\s+(install|i|add)\s+[^\n]*@vercel/blob\b'
     - '\bpnpm\s+(install|i|add)\s+[^\n]*@vercel/blob\b'
@@ -80,6 +90,38 @@ metadata:
     - "@vercel/postgres"
     - "@supabase/supabase-js"
     - "@prisma/client"
+  promptSignals:
+    phrases:
+      - "add a database"
+      - "set up a database"
+      - "need a database"
+      - "add postgres"
+      - "set up postgres"
+      - "add redis"
+      - "persist data"
+      - "save todos"
+      - "persist todos"
+      - "store todos"
+      - "where do I store"
+    allOf:
+      - ["add", "database"]
+      - ["set", "up", "database"]
+      - ["need", "database"]
+      - ["store", "users"]
+      - ["save", "users"]
+      - ["persist", "users"]
+      - ["upload", "files"]
+      - ["store", "images"]
+    anyOf:
+      - "database"
+      - "postgres"
+      - "neon"
+      - "upstash"
+      - "redis"
+      - "blob storage"
+      - "drizzle"
+      - "prisma"
+    minScore: 6
 validate:
   -
     pattern: from\s+['"]@vercel/kv['"]
@@ -175,10 +217,46 @@ You are an expert in Vercel's storage options. Know which products are active, w
 
 Choose storage provisioning paths in this order:
 
-1. **Preferred**: Vercel-managed Neon/Upstash through the Vercel Marketplace (`vercel integration add ...` or dashboard). This path auto-provisions accounts/resources and injects environment variables into the linked Vercel project.
+1. **Preferred**: Vercel-managed Neon/Upstash through the Vercel Marketplace (`vercel integration add ...` or dashboard). This path auto-provisions the resource, connects it to the linked project across all environments, and runs `vercel env pull --yes` automatically.
 2. **Fallback**: Provider CLI/manual provisioning only when Marketplace is unavailable or you must use an existing external account.
 
-When using fallback/manual provisioning, you must add/sync environment variables yourself and then re-run `vercel env pull .env.local --yes` locally.
+For the manual fallback path you must add/sync environment variables yourself and then run `vercel env pull .env.local --yes` locally. The Marketplace path does this for you.
+
+### Marketplace bootstrap commands
+
+Run from inside the project directory. If `.vercel/project.json` doesn't exist, link first.
+
+```bash
+test -f .vercel/project.json || vercel link
+vercel integration discover                       # browse slugs (or skip if you know it)
+vercel integration guide neon --framework nextjs  # framework-specific setup snippets
+vercel integration add neon                       # provision + auto-connect + auto env pull
+pnpm add @neondatabase/serverless                 # then install the SDK
+```
+
+After `vercel integration add`, wait **1–3 minutes** before debugging connection failures — transient HTTP 500s usually mean the database is still provisioning. If env sync was skipped (or you used `--no-env-pull`), run `vercel env pull .env.local --yes` to refresh local credentials.
+
+### Multiple resources in one project
+
+When provisioning two of the same resource type, the second collides with the first's env var names. Use `--prefix` to rename:
+
+```bash
+vercel integration add neon --prefix NEON_PRIMARY_
+vercel integration add neon --prefix NEON_REPLICA_
+```
+
+This produces `NEON_PRIMARY_DATABASE_URL` and `NEON_REPLICA_DATABASE_URL` etc. instead of both writing `DATABASE_URL`. The prefix is forwarded to the Marketplace API; base names come from each integration's contract.
+
+### Marketplace env var names
+
+Marketplace-provisioned env var names come from each integration. Common ones for the providers in this skill:
+
+- **Neon**: `DATABASE_URL` (verified via `vercel integration add neon` eval that checks for this key after install)
+- **Upstash Redis**: `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` (matches what `Redis.fromEnv()` reads)
+- **Vercel Blob**: `BLOB_READ_WRITE_TOKEN`
+- **Edge Config**: `EDGE_CONFIG`
+
+Run `vercel env ls` after install to confirm the exact keys provisioned for your project — integrations occasionally evolve their env-var contracts.
 
 ## Active First-Party Storage
 
@@ -503,18 +581,46 @@ Install via Vercel Marketplace: `vercel integration add turso`
 
 ## Installing Marketplace Storage
 
-Use the Vercel CLI or the Marketplace dashboard at `https://vercel.com/dashboard/{team}/stores`:
+The Marketplace install commands (see also "Marketplace bootstrap commands" near the top of this skill):
 
 ```bash
-# Install a storage integration (auto-provisions env vars)
-vercel integration add neon
-vercel integration add upstash
-
-# List installed integrations
-vercel integration list
+vercel integration add neon                       # Postgres
+vercel integration add upstash                    # Redis / KV
+vercel integration add supabase                   # Postgres + auth + realtime + storage
+vercel integration add prisma                     # Prisma Accelerate (connection pooling)
+vercel integration add mongodb-atlas              # MongoDB
+vercel integration add turso                      # libSQL (edge-native SQLite)
+vercel install <slug>                             # alias for `vercel integration add`
 ```
 
-Browse additional storage options at the [Vercel Marketplace](https://vercel.com/marketplace). Installing via the CLI or dashboard (`https://vercel.com/dashboard/{team}/integrations`) automatically provisions accounts, creates databases, and sets environment variables.
+`vercel integration add <slug>` provisions the resource, connects it to the linked project across `production`, `preview`, and `development`, and runs `vercel env pull --yes` automatically. To opt out: `--no-connect` skips the project link (and env pull); `--no-env-pull` skips only the local env sync; `--environment production -e preview` connects to a subset.
+
+Common flags:
+
+```bash
+vercel integration add neon --plan pro                                    # specific billing plan
+vercel integration add neon -m region=us-east-1 -m "readRegions=sfo1"    # provider metadata
+vercel integration add neon --name my-primary-db                          # custom resource name
+vercel integration add aws/aws-dynamodb                                   # multi-product integration
+vercel integration add neon --format=json                                 # machine-readable output
+```
+
+Listing and lifecycle (run inside a linked project):
+
+```bash
+vercel integration list                           # Marketplace resources for the linked project
+vercel integration list --all                     # all team resources
+vercel integration installations                  # team-level installations (different from `list`)
+vercel integration balance neon                   # usage / credit balance for prepayment plans
+vercel integration open neon                      # SSO into provider dashboard
+vercel integration update neon --projects all     # change which projects can use the installation
+
+# Removal: resources first, then the installation
+vercel ir remove <resource> --disconnect-all --yes
+vercel integration remove neon --yes
+```
+
+Browse the catalog at the [Vercel Marketplace](https://vercel.com/marketplace) or via `vercel integration discover`.
 
 ## Official Documentation
 

--- a/tests/snapshots/inject-crons.snap
+++ b/tests/snapshots/inject-crons.snap
@@ -2,33 +2,31 @@
   "version": 1,
   "toolName": "Read",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
     "vercel-functions"
   ],
   "injectedSkills": [
-    "cron-jobs",
-    "vercel-cli",
-    "vercel-functions"
-  ],
-  "summaryOnly": [],
-  "droppedByCap": [
+    "vercel-functions",
     "deployments-cicd",
     "routing-middleware"
   ],
+  "contextChunks": [
+    "compute-routing"
+  ],
+  "summaryOnly": [],
   "droppedByBudget": [],
   "reasons": {
-    "cron-jobs": {
-      "trigger": "basename",
-      "reasonCode": "pattern-match"
-    },
-    "vercel-cli": {
-      "trigger": "basename",
-      "reasonCode": "pattern-match"
-    },
     "vercel-functions": {
+      "trigger": "basename",
+      "reasonCode": "pattern-match"
+    },
+    "deployments-cicd": {
+      "trigger": "basename",
+      "reasonCode": "pattern-match"
+    },
+    "routing-middleware": {
       "trigger": "basename",
       "reasonCode": "pattern-match"
     }

--- a/tests/snapshots/inject-functions.snap
+++ b/tests/snapshots/inject-functions.snap
@@ -2,7 +2,6 @@
   "version": 1,
   "toolName": "Read",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
@@ -11,13 +10,12 @@
   "injectedSkills": [
     "vercel-functions",
     "vercel-cli",
-    "cron-jobs"
+    "deployments-cicd"
+  ],
+  "contextChunks": [
+    "compute-routing"
   ],
   "summaryOnly": [],
-  "droppedByCap": [
-    "deployments-cicd",
-    "routing-middleware"
-  ],
   "droppedByBudget": [],
   "reasons": {
     "vercel-functions": {
@@ -28,7 +26,7 @@
       "trigger": "basename",
       "reasonCode": "pattern-match"
     },
-    "cron-jobs": {
+    "deployments-cicd": {
       "trigger": "basename",
       "reasonCode": "pattern-match"
     }

--- a/tests/snapshots/inject-headers.snap
+++ b/tests/snapshots/inject-headers.snap
@@ -2,7 +2,6 @@
   "version": 1,
   "toolName": "Edit",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
@@ -13,11 +12,10 @@
     "vercel-cli",
     "vercel-functions"
   ],
-  "summaryOnly": [],
-  "droppedByCap": [
-    "cron-jobs",
-    "deployments-cicd"
+  "contextChunks": [
+    "compute-routing"
   ],
+  "summaryOnly": [],
   "droppedByBudget": [],
   "reasons": {
     "routing-middleware": {

--- a/tests/snapshots/inject-mixed.snap
+++ b/tests/snapshots/inject-mixed.snap
@@ -2,7 +2,6 @@
   "version": 1,
   "toolName": "Edit",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
@@ -10,25 +9,24 @@
   ],
   "injectedSkills": [
     "vercel-functions",
-    "cron-jobs",
-    "deployments-cicd"
+    "deployments-cicd",
+    "routing-middleware"
+  ],
+  "contextChunks": [
+    "compute-routing"
   ],
   "summaryOnly": [],
-  "droppedByCap": [
-    "routing-middleware",
-    "vercel-cli"
-  ],
   "droppedByBudget": [],
   "reasons": {
     "vercel-functions": {
       "trigger": "basename",
       "reasonCode": "pattern-match"
     },
-    "cron-jobs": {
+    "deployments-cicd": {
       "trigger": "basename",
       "reasonCode": "pattern-match"
     },
-    "deployments-cicd": {
+    "routing-middleware": {
       "trigger": "basename",
       "reasonCode": "pattern-match"
     }

--- a/tests/snapshots/inject-redirects.snap
+++ b/tests/snapshots/inject-redirects.snap
@@ -2,7 +2,6 @@
   "version": 1,
   "toolName": "Read",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
@@ -13,11 +12,10 @@
     "vercel-cli",
     "vercel-functions"
   ],
-  "summaryOnly": [],
-  "droppedByCap": [
-    "cron-jobs",
-    "deployments-cicd"
+  "contextChunks": [
+    "compute-routing"
   ],
+  "summaryOnly": [],
   "droppedByBudget": [],
   "reasons": {
     "routing-middleware": {

--- a/tests/snapshots/inject-rewrites.snap
+++ b/tests/snapshots/inject-rewrites.snap
@@ -2,7 +2,6 @@
   "version": 1,
   "toolName": "Write",
   "matchedSkills": [
-    "cron-jobs",
     "deployments-cicd",
     "routing-middleware",
     "vercel-cli",
@@ -13,11 +12,10 @@
     "vercel-cli",
     "vercel-functions"
   ],
-  "summaryOnly": [],
-  "droppedByCap": [
-    "cron-jobs",
-    "deployments-cicd"
+  "contextChunks": [
+    "compute-routing"
   ],
+  "summaryOnly": [],
   "droppedByBudget": [],
   "reasons": {
     "routing-middleware": {


### PR DESCRIPTION
## Summary

Storage code edits (e.g., editing `src/lib/db.ts`, installing `@neondatabase/serverless`) trigger the `vercel-storage` skill but never the `marketplace` skill — so a user building a todo app gets storage SDK guidance with no install flow.

`chainTo` rules in skill frontmatter (which would seem to bridge this) are **parsed but never executed** at runtime — verified against `hooks/src/pretooluse-skill-inject.mts:435` and `hooks/src/prompt-analysis.mts:133`. The mechanism is documentation, not behavior.

This PR makes `vercel-storage` self-sufficient for the bootstrap path.

## Changes

**`skills/vercel-storage/SKILL.md`:**
- Add `lib/db.*`, `src/lib/db.*`, `src/db.*`, `server/db.*`, `src/server/db.*` path patterns so common app file conventions trigger the skill
- Add `promptSignals` block (skill previously had only a `retrieval` block which the prompt-scoring hook ignores)
- Inline a Marketplace bootstrap section: `vercel link` prerequisite, `vercel integration discover` / `guide --framework nextjs` / `add`, the 1–3 minute provisioning wait, `--prefix` for multi-resource projects
- Document Marketplace env var names (`DATABASE_URL` for Neon, `UPSTASH_REDIS_REST_URL`/`TOKEN` for Upstash, `BLOB_READ_WRITE_TOKEN`, `EDGE_CONFIG`) so generated code reads the actual provisioned keys
- Expand the install reference with common flags (`--plan`, `--metadata`, `--name`, `--no-connect`, `--no-env-pull`, `--environment`, `--format=json`), the `vercel install` alias, the `vercel integration installations` vs `list` distinction, and the full removal workflow (resources first via `vercel ir remove`, then `vercel integration remove`)

**Snapshot updates:**
- `tests/snapshots/inject-*.snap` files — pre-existing drift from main churn between 2026-04-14 and now, swept up by `bun run test:update-snapshots`. None of these snapshots reference storage; flag if you want them split into a separate cleanup PR.

## Verification

- All flag and lifecycle claims verified against `vercel/vercel/packages/cli/src/commands/integration/command.ts` and `integration-resource/command.ts`
- `DATABASE_URL` claim verified against the Neon Marketplace install eval (`vercel/vercel/packages/cli/evals/evals/marketplace/install-neon-postgres/EVAL.ts:98-110`) which checks for that key after install
- Codex review surfaced two corrections (initial commit had `POSTGRES_URL` for Neon and `KV_REST_API_*` for Upstash — both wrong) which are addressed in the amended commit
- `bun run build:manifest` regenerated; manifest diff is clean (only vercel-storage entries + timestamp)
- `bun test` shows no new failures vs main; pre-existing failures (`test-broken-cmd`, prompt-matching-eval, session-timeline-subagent) are unchanged

## Test plan

- [ ] In a sample Next.js project, edit `src/lib/db.ts` — verify `vercel-storage` is injected
- [ ] Type "I need to add a database" — verify prompt scoring picks up `vercel-storage`
- [ ] Type "persist todos" — verify allOf rule fires
- [ ] Run `vercel integration add neon` against a real project and confirm `DATABASE_URL` (not `POSTGRES_URL`) is the env var injected — sanity check on the env-var documentation

## Out of scope

Other findings from the same audit that are NOT in this PR:
- `vercel integration list` mislabel ("List installed integrations" vs actual project resources) — exists in `marketplace:172` and elsewhere
- `accept-terms` subcommand — user signaled assume revert soon, intentionally not added
- `installations` and `update` subcommands missing from `vercel-cli/references/integrations.md`
- Agent JSON mode (`--non-interactive`, `AGENT_REASON`, `next[]`) undocumented anywhere

## Related

Codex audit + Devil's-advocate review during `/xx` session: confirmed the asymmetric trigger problem (marketplace skill never fires for storage code) and that `chainTo` is inert at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)