### PR TITLE
fix(ai-gateway): remove overbroad model-slug rule (closes #60)

### DIFF
--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -969,11 +969,6 @@
       ],
       "validate": [
         {
-          "pattern": "\\d+-\\d+[)'\"]",
-          "message": "Model slug uses hyphens — use dots not hyphens for version numbers (e.g., claude-sonnet-4.6)",
-          "severity": "error"
-        },
-        {
           "pattern": "AI_GATEWAY_API_KEY",
           "message": "Consider OIDC-based auth via vercel env pull for automatic token management — AI_GATEWAY_API_KEY works but requires manual rotation",
           "severity": "recommended"

--- a/skills/ai-gateway/SKILL.md
+++ b/skills/ai-gateway/SKILL.md
@@ -18,10 +18,12 @@ metadata:
     - '\bbun\s+(install|i|add)\s+[^\n]*@ai-sdk/gateway\b'
     - '\byarn\s+add\s+[^\n]*@ai-sdk/gateway\b'
 validate:
-  -
-    pattern: \d+-\d+[)'"]
-    message: 'Model slug uses hyphens — use dots not hyphens for version numbers (e.g., claude-sonnet-4.6)'
-    severity: error
+  # Removed: the prior rule `\d+-\d+[)'"]` was too broad — it fired on any
+  # hyphenated digit pair followed by a quote/paren, which produced false
+  # positives on date strings ("01-15-2024"), package versions, and on
+  # direct provider SDK calls like `anthropic('claude-sonnet-4-6')` where
+  # hyphens are CORRECT (Anthropic's canonical model IDs use hyphens; only
+  # the gateway slug form uses dots). See vercel/vercel-plugin#60.
   -
     pattern: AI_GATEWAY_API_KEY
     message: 'Consider OIDC-based auth via vercel env pull for automatic token management — AI_GATEWAY_API_KEY works but requires manual rotation'
@@ -134,11 +136,11 @@ const result = await generateText({
 ## Model Slug Rules (Critical)
 
 - Always use `provider/model` format (for example `openai/gpt-5.4`).
-- Versioned slugs use dots for versions, not hyphens:
-  - Correct: `anthropic/claude-sonnet-4.6`
-  - Incorrect: `anthropic/claude-sonnet-4-6`
+- Naming convention depends on which call surface you're using:
+  - **Vercel AI Gateway** (`gateway('provider/...')` or plain string): the gateway's catalog uses dots in version numbers — e.g. `anthropic/claude-opus-4.6`, `openai/gpt-5.4`. See [Vercel AI Gateway models](https://vercel.com/ai-gateway/models).
+  - **Direct provider SDK** (`anthropic('...')`, `openai('...')`): use the provider's native model IDs, which Anthropic publishes with hyphens — e.g. `claude-sonnet-4-6`, `claude-opus-4-7`. See [Anthropic models](https://docs.anthropic.com/en/docs/about-claude/models).
 - Before hardcoding model IDs, call `gateway.getAvailableModels()` and pick from the returned IDs.
-- Default text models: `openai/gpt-5.4` or `anthropic/claude-sonnet-4.6`.
+- Default text models: `openai/gpt-5.4` or `anthropic/claude-opus-4.6`.
 - Do not default to outdated choices like `openai/gpt-4o`.
 
 ```ts

--- a/tests/posttooluse-chain.test.ts
+++ b/tests/posttooluse-chain.test.ts
@@ -1143,7 +1143,7 @@ describe("real-world chain and validate scenarios", () => {
       `import { generateText } from 'ai';`,
       ``,
       `const result = await generateText({`,
-      `  model: anthropic('claude-sonnet-4.6'),`,
+      `  model: anthropic('claude-sonnet-4-6'),`,
       `  prompt: 'Hello!',`,
       `});`,
     ].join("\n");

--- a/tests/posttooluse-validate.test.ts
+++ b/tests/posttooluse-validate.test.ts
@@ -187,29 +187,37 @@ describe("posttooluse-validate.mjs", () => {
       }
     });
 
-    test("detects gateway from 'ai' with hyphenated model slug", async () => {
-      writeFileSync(testFile, [
-        `import { generateText, gateway } from 'ai';`,
-        ``,
-        `const result = await generateText({`,
-        `  model: gateway('anthropic/claude-sonnet-4-6'),`,
-        `  prompt: 'Hello!',`,
-        `});`,
-      ].join("\n"));
-      const { code, stdout } = await runHook({
-        tool_name: "Write",
-        tool_input: { file_path: testFile },
-      });
-      expect(code).toBe(0);
-      const result = JSON.parse(stdout);
-      expect(result.hookSpecificOutput).toBeDefined();
-      const ctx = result.hookSpecificOutput.additionalContext;
-      expect(ctx).toContain("VALIDATION");
-      expect(ctx).toContain("dots not hyphens");
-      const meta = extractPostValidation(result.hookSpecificOutput);
-      expect(meta).toBeDefined();
-      expect(meta.errorCount).toBeGreaterThan(0);
-      expect(meta.matchedSkills).toContain("ai-gateway");
+    test("hyphenated and dotted model slugs both pass — slug-form rule removed in #60", async () => {
+      // Issue #60: the prior `\d+-\d+[)'"]` rule false-positived on
+      // Anthropic's canonical hyphenated slugs and on date strings.
+      // Rule removed; both gateway-catalog (dots) and provider-canonical
+      // (hyphens) forms must pass without raising "dots not hyphens".
+      // ai-gateway must still be detected on the file (importPatterns
+      // includes 'ai'), and the missing-provider rule still fires for
+      // bare model strings.
+      for (const slug of ["anthropic/claude-sonnet-4-6", "anthropic/claude-sonnet-4.6"]) {
+        writeFileSync(testFile, [
+          `import { generateText, gateway } from 'ai';`,
+          ``,
+          `const result = await generateText({`,
+          `  model: gateway('${slug}'),`,
+          `  prompt: 'Hello!',`,
+          `});`,
+        ].join("\n"));
+        const { code, stdout } = await runHook({
+          tool_name: "Write",
+          tool_input: { file_path: testFile },
+        });
+        expect(code).toBe(0);
+        const result = JSON.parse(stdout);
+        const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+        // The deleted rule's message must not appear for either form.
+        expect(ctx).not.toContain("dots not hyphens");
+        const meta = extractPostValidation(result.hookSpecificOutput);
+        if (meta) {
+          expect(meta.matchedSkills).toContain("ai-gateway");
+        }
+      }
     });
 
     test("no output for file that doesn't match any skill", async () => {

--- a/tests/validate-rules.test.ts
+++ b/tests/validate-rules.test.ts
@@ -423,15 +423,25 @@ describe("ai-sdk validation rules", () => {
 // ---------------------------------------------------------------------------
 
 describe("ai-gateway validation rules", () => {
-  test("flags hyphenated model slug (anthropic/claude-sonnet-4-6)", () => {
+  test("does NOT flag hyphenated model slug — both gateway-form (dots) and provider-canonical (hyphens) are valid", () => {
+    // Issue #60: the prior rule `\d+-\d+[)'"]` flagged hyphenated model
+    // slugs as typos expecting dots. But Anthropic's canonical IDs are
+    // hyphenated (`claude-sonnet-4-6`), and the rule also false-positived
+    // on date strings, package versions, and direct provider SDK calls.
+    // Rule was removed; both forms must now pass without violation.
     const data = loadRealRules();
-    const violations = runValidation(
+    const hyphenViolations = runValidation(
       `gateway('anthropic/claude-sonnet-4-6')\n`,
       ["ai-gateway"],
       data!.rulesMap,
     );
-    // This pattern is a plain string, no escaping needed
-    expect(violations.some((v) => v.message.includes("dots not hyphens"))).toBe(true);
+    const dotViolations = runValidation(
+      `gateway('anthropic/claude-sonnet-4.6')\n`,
+      ["ai-gateway"],
+      data!.rulesMap,
+    );
+    expect(hyphenViolations.some((v) => v.message.includes("dots not hyphens"))).toBe(false);
+    expect(dotViolations.some((v) => v.message.includes("dots not hyphens"))).toBe(false);
   });
 
   test("AI_GATEWAY_API_KEY is recommended severity (fallback auth)", () => {
@@ -1143,10 +1153,10 @@ describe("multi-skill overlap", () => {
     const data = loadRealRules();
     // Use patterns that actually work (no double-escape issues):
     // ai-sdk: import from 'openai' (direct import pattern)
-    // ai-gateway: anthropic/claude-sonnet-4-6 (hyphenated slug)
+    // ai-gateway: gateway('opaque') — missing provider/ prefix (error rule)
     const content = [
       `import OpenAI from 'openai';`,
-      `const result = await generateText({ model: gateway('anthropic/claude-sonnet-4-6') });`,
+      `const result = await generateText({ model: gateway('opaque') });`,
     ].join("\n");
     const violations = runValidation(content, ["ai-sdk", "ai-gateway"], data!.rulesMap);
 
@@ -1177,10 +1187,10 @@ describe("multi-skill overlap", () => {
   test("overlapping rules don't suppress each other", () => {
     const data = loadRealRules();
     // ai-sdk flags: import from 'openai'
-    // ai-gateway flags: anthropic/claude-sonnet-4-6 (hyphenated slug)
+    // ai-gateway flags: gateway('opaque') — missing provider/ prefix
     const content = [
       `import OpenAI from 'openai';`,
-      `gateway('anthropic/claude-sonnet-4-6')`,
+      `gateway('opaque')`,
     ].join("\n");
     const violations = runValidation(content, ["ai-sdk", "ai-gateway"], data!.rulesMap);
 
@@ -1195,12 +1205,12 @@ describe("multi-skill overlap", () => {
     const content = [
       `import OpenAI from 'openai';`,     // line 1 - ai-sdk error
       `const x = 1;`,                      // line 2 - clean
-      `gateway('anthropic/claude-sonnet-4-6')`, // line 3 - ai-gateway error
+      `gateway('opaque')`,                 // line 3 - ai-gateway error (missing provider/)
     ].join("\n");
     const violations = runValidation(content, ["ai-sdk", "ai-gateway"], data!.rulesMap);
 
     const aiSdkV = violations.find((v) => v.skill === "ai-sdk" && v.message.includes("@ai-sdk/openai"));
-    const aiGwV = violations.find((v) => v.skill === "ai-gateway" && v.message.includes("dots not hyphens"));
+    const aiGwV = violations.find((v) => v.skill === "ai-gateway" && v.message.includes("missing provider/ prefix"));
     expect(aiSdkV).toBeDefined();
     expect(aiSdkV!.line).toBe(1);
     expect(aiGwV).toBeDefined();
@@ -1439,13 +1449,17 @@ describe("no false positives", () => {
     expect(errors.length).toBe(0);
   });
 
-  test("correctly versioned anthropic slug does not flag", () => {
+  test("anthropic slug — both dot and hyphen forms pass (rule removed in #60)", () => {
     const data = loadRealRules();
-    const content = `gateway('anthropic/claude-sonnet-4.6')\n`;
-    const violations = runValidation(content, ["ai-gateway"], data!.rulesMap);
-    // The dot version should NOT be flagged (only hyphenated version is wrong)
-    const slugError = violations.filter((v) => v.message.includes("dots not hyphens"));
-    expect(slugError.length).toBe(0);
+    // Post-#60: the dot-vs-hyphen rule is gone. Both gateway-catalog form
+    // (dots, e.g. anthropic/claude-sonnet-4.6) and Anthropic-canonical form
+    // (hyphens, e.g. anthropic/claude-sonnet-4-6) must pass without
+    // raising a "dots not hyphens" violation.
+    for (const slug of ["anthropic/claude-sonnet-4.6", "anthropic/claude-sonnet-4-6"]) {
+      const violations = runValidation(`gateway('${slug}')\n`, ["ai-gateway"], data!.rulesMap);
+      const slugError = violations.filter((v) => v.message.includes("dots not hyphens"));
+      expect(slugError.length).toBe(0);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Removes the `\d+-\d+[)'"]` model-slug validation rule on the `ai-gateway` skill. The rule was supposed to catch typo'd hyphenated slugs in `gateway('…')` calls but in practice produces false positives that compound into the broader noise problem documented in #38 / #59.

Closes #60.

## The bug, by example

Authoritative Anthropic docs ([platform.claude.com/docs/en/docs/about-claude/models](https://platform.claude.com/docs/en/docs/about-claude/models), verified 2026-04-30):

| Claude API ID | `claude-sonnet-4-6` |
| Claude API alias | `claude-sonnet-4-6` |
| Pricing | $3 / $15 per MTok |

Anthropic's canonical model identifiers use **hyphens**. They have used hyphens consistently across `claude-3-5-sonnet`, `claude-opus-4-1`, `claude-sonnet-4-5`, `claude-opus-4-7` — every model.

A real production app shipped this code:

```ts
import { anthropic } from '@ai-sdk/anthropic'
const result = await generateText({
  model: anthropic('claude-sonnet-4.6'),  // typo: dot, written this way because the validator said so
  ...
})
```

Anthropic API responded `model_not_found`, every coach/critique call surfaced as `ai_error` to end users for several days. Fixing the slug to `claude-sonnet-4-6` (the form the validator was flagging as wrong) restored service.

## Three failure modes of the deleted rule

1. **Inverts Anthropic's actual convention.** Direct provider SDK calls (`anthropic('…')`, `openai('…')`) take the provider's native model IDs, which Anthropic publishes with hyphens. The rule fires on every such call as a false positive.

2. **Matches outside model-slug context.** The pattern `\d+-\d+[)'"]` greedily matches any digit-hyphen-digit followed by `)`, `'`, or `"`. Real-world hits include date strings (`"01-15-2024"`), package versions, file paths, semver ranges in JSDoc — anywhere the substring appears in code.

3. **Trains operators to dismiss validator output.** Combined with the over-matching documented in #59 (validator scans full file content and re-matches its own SKILL.md rule strings), users learn to ignore all plugin warnings, losing the value of the rules that *are* correct.

## Why the gateway-vs-direct asymmetry exists, and why a rule can't fix it

The Vercel AI Gateway's catalog uses **dots** in version numbers. Per [vercel/docs/ai-gateway/models-and-providers](https://vercel.com/docs/ai-gateway/models-and-providers), the Gateway example is:

```ts
model: gateway('anthropic/claude-opus-4.6')
```

So both these calls are correct in their respective contexts:

```ts
gateway('anthropic/claude-opus-4.6')   // Gateway catalog form, dots
anthropic('claude-opus-4-7')           // Direct provider SDK, hyphens
```

A regex on the file content can't tell which surface a string is destined for, so any version of this rule will be wrong half the time. The remaining provider/-prefix rule (`gateway\(['"][^'"/]+['"]\)`) still enforces the actual hard constraint: gateway calls must use `provider/model` format. Slug typos within that format will surface from the gateway itself with a clearer error than a regex lint can produce.

## Files changed

| File | Change |
|---|---|
| `skills/ai-gateway/SKILL.md` | Remove the `validate:` rule (kept as comment with #60 pointer); rewrite Model Slug Rules prose to document gateway-vs-direct asymmetry honestly |
| `generated/skill-manifest.json` | Drop the corresponding rule entry |
| `tests/validate-rules.test.ts` | Invert the direct assertion (line 426) — both forms now must NOT raise the deleted message; update 3 multi-skill overlap tests to use `gateway('opaque')` (existing missing-provider rule) as the ai-gateway trigger; extend the negative test to cover both forms |
| `tests/posttooluse-validate.test.ts` | Convert "detects gateway from 'ai' with hyphenated model slug" test to assert NO violation, looped over both hyphen and dot forms; ai-gateway skill match still expected |
| `tests/posttooluse-chain.test.ts` | Cosmetic: fix `anthropic('claude-sonnet-4.6')` → `anthropic('claude-sonnet-4-6')` in test fixture (test logic unchanged) |

## Test plan

- [x] `git diff --stat` — 5 files, +73/-54
- [x] Manually validated assertion polarity — for each touched test, confirmed expected violations match remaining ai-gateway rule set
- [ ] CI: `bun test` — local environment doesn't have bun; relying on PR CI

## Out of scope

- The broader [#59](https://github.com/vercel/vercel-plugin/issues/59) (validator over-matches inside SKILL.md content) — separate refactor; this PR's scope is just the slug rule.
- Migration from `@ai-sdk/anthropic` direct calls to AI Gateway — that's a downstream consumer concern, not the plugin's job to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)