### PR TITLE
vercel-functions: skip default-export rule for App Router pages

### DIFF
--- a/generated/skill-manifest.json
+++ b/generated/skill-manifest.json
@@ -4398,7 +4398,8 @@
         {
           "pattern": "export\\s+default\\s+function",
           "message": "Use named exports (GET, POST, PUT, DELETE) instead of default export for route handlers",
-          "severity": "error"
+          "severity": "error",
+          "skipIfFileContains": "(?:^|\\\\n)\\\\s*['\\\"]use\\\\s+client['\\\"]|export\\\\s+const\\\\s+(?:metadata|dynamic|revalidate|fetchCache|runtime)\\\\b|export\\\\s+default\\\\s+(?:async\\\\s+)?function\\\\s+\\\\w*(?:Page|Layout|Loading|Error|NotFound|Sitemap|Template|Default|sitemap|robots|opengraph|manifest)\\\\b|<[A-Z][A-Za-z0-9]*|\\\\{\\\\s*children\\\\s*[,}:]|MetadataRoute\\\\.|from\\\\s+['\\\"]next/(?:font|image|link|navigation|headers|cookies)['\\\"]"
         },
         {
           "pattern": "NextApiRequest|NextApiResponse",

--- a/skills/vercel-functions/SKILL.md
+++ b/skills/vercel-functions/SKILL.md
@@ -27,6 +27,13 @@ validate:
     pattern: export\s+default\s+function
     message: 'Use named exports (GET, POST, PUT, DELETE) instead of default export for route handlers'
     severity: error
+    # Skip on App Router page / layout / loading / error / not-found / sitemap / template / default files,
+    # which require a default export by Next.js convention. Detected via the 'use client' directive,
+    # an App Router config export (metadata, dynamic, revalidate, fetchCache, runtime), an `export default
+    # function` whose name matches an App Router file (Page / Layout / Loading / etc.), or any JSX
+    # element with a capitalised component tag — all signals that the file is a page-style file rather
+    # than a route handler. See anthropics/claude-code#54989.
+    skipIfFileContains: "(?:^|\\n)\\s*['\"]use\\s+client['\"]|export\\s+const\\s+(?:metadata|dynamic|revalidate|fetchCache|runtime)\\b|export\\s+default\\s+(?:async\\s+)?function\\s+\\w*(?:Page|Layout|Loading|Error|NotFound|Sitemap|Template|Default|sitemap|robots|opengraph|manifest)\\b|<[A-Z][A-Za-z0-9]*|\\{\\s*children\\s*[,}:]|MetadataRoute\\.|from\\s+['\"]next/(?:font|image|link|navigation|headers|cookies)['\"]"
   -
     pattern: NextApiRequest|NextApiResponse
     message: 'NextApiRequest/NextApiResponse are Pages Router types — use Web API Request/Response'


### PR DESCRIPTION
Fixes the false-positive `Use named exports (GET, POST, PUT, DELETE) instead of default export for route handlers` ERROR that fires on every `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `not-found.tsx`, `sitemap.ts`, and `template.tsx` in a Next.js App Router project.

Refs anthropics/claude-code#54989 (the bug was reported in `claude-code`, but the validation rule lives here in `skills/vercel-functions/SKILL.md` lines 25-29).

## Problem

The current rule:

```yaml
validate:
  -
    pattern: export\s+default\s+function
    message: 'Use named exports (GET, POST, PUT, DELETE) instead of default export for route handlers'
    severity: error
```

matches any default-exported function. Next.js App Router *requires* default exports for `page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`, `not-found.tsx`, `sitemap.ts`, and `template.tsx`, so the rule fires `[ERROR]` on every Write/Edit to any of those files. The reporter has a 44-page project where this fires constantly and cannot be suppressed without disabling the entire skill.

## Fix

Add a `skipIfFileContains` regex (the same shape used in `skills/routing-middleware/SKILL.md`) that suppresses the rule when the file shows strong signals of being an App Router file rather than a route handler:

| Signal | Catches |
| --- | --- |
| `'use client'` directive | client components |
| `export const metadata\|dynamic\|revalidate\|fetchCache\|runtime` | App Router config exports |
| `export default function …(Page\|Layout\|Loading\|Error\|NotFound\|Sitemap\|Template\|Default)` (also lower-case `sitemap`/`robots`/`opengraph`/`manifest`) | App Router file conventions |
| `<[A-Z]…` (capitalised JSX tag) | any JSX-returning page |
| `{ children }` destructure | layouts and templates |
| `MetadataRoute.` | sitemap/robots/manifest helpers |
| `from 'next/(font\|image\|link\|navigation\|headers\|cookies)'` | App Router imports |

Each of these is overwhelmingly common in App Router pages and overwhelmingly absent from route handlers. A buggy `export default function handler` inside a `route.ts` still fires the rule because none of the patterns match.

## Why `skipIfFileContains` and not a new field

The reporter suggested `onlyIfFilename` / `skipIfFilename`. Adding a new schema field requires the downstream consumer (claude-code) to honor it, otherwise the field is inert and the false positive remains. `skipIfFileContains` is already supported and already used by `skills/routing-middleware/SKILL.md`, so this PR fixes the bug today without coordinating new field support.

## Verification

Tested the regex against representative content for each affected file plus the buggy route handler case (Python regex used for portability):

```
page.tsx (server)                          fires=True  skip=True  -> skipped (correct)
page.tsx (client - 'use client')           fires=True  skip=True  -> skipped (correct)
layout.tsx (RootLayout)                    fires=True  skip=True  -> skipped (correct)
layout.tsx (MarketingLayout)               fires=True  skip=True  -> skipped (correct)
sitemap.ts                                 fires=True  skip=True  -> skipped (correct)
loading.tsx                                fires=True  skip=True  -> skipped (correct)
not-found.tsx                              fires=True  skip=True  -> skipped (correct)
route.ts (BUG: export default fn handler)  fires=True  skip=False -> flagged (correct)
route.ts (BUG: export default with NextResponse) fires=True  skip=False -> flagged (correct)
```

Plugin-level checks still pass:

```
$ bun run validate
PASSED with 1 warning(s)

$ bun run build
build:skills — 0 updated, 10 unchanged, 0 errors
build:from-skills — 0 updated, 8 unchanged, 0 errors
```
