### PR TITLE
feat: add Kimi Code plugin manifest

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "vercel-plugin",
+  "version": "0.44.0",
+  "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
+  "keywords": [
+    "vercel",
+    "nextjs",
+    "ai-sdk",
+    "turborepo",
+    "turbopack",
+    "workflow",
+    "deployment",
+    "edge-functions",
+    "serverless",
+    "ai-gateway"
+  ],
+  "homepage": "https://github.com/vercel/vercel-plugin",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Vercel",
+    "url": "https://github.com/vercel"
+  },
+  "skills": ["./skills"],
+  "commands": ["./commands"],
+  "mcpServers": {
+    "vercel": {
+      "transport": "http",
+      "url": "https://mcp.vercel.com"
+    }
+  },
+  "interface": {
+    "displayName": "Vercel",
+    "shortDescription": "Vercel ecosystem expert: skills and workflows for Next.js, AI SDK, and more.",
+    "developerName": "Vercel",
+    "websiteURL": "https://vercel.com"
+  }
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.44.0",
+  "version": "0.45.1",
   "description": "Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
   "keywords": [
     "vercel",


### PR DESCRIPTION
## Summary

Add `.kimi-plugin/plugin.json`, a plugin manifest for [Kimi Code](https://github.com/MoonshotAI/kimi-code), so the Vercel plugin can be installed and used in Kimi Code alongside the existing Claude Code (`.claude-plugin/`), Cursor (`.cursor-plugin/`), and open-plugin (`.plugin/`) manifests.

## What it includes

- `skills`: `./skills` — all 29 Vercel skills, available on-demand
- `commands`: `./commands` — the 5 slash commands (`/vercel-plugin:deploy`, etc.)
- `mcpServers`: the `vercel` HTTP MCP server (`https://mcp.vercel.com`)
- Standard metadata (`name`, `version`, `description`, `keywords`, `homepage`, `license`, `author`, `interface`)

## What it intentionally omits

- **`hooks`**: the existing `hooks/hooks.json` handlers are Claude-Code-specific (they reference `${CLAUDE_PLUGIN_ROOT}` and write to `CLAUDE.md`, which Kimi Code does not read). Porting them needs a Kimi-compatible handler, which can be a follow-up.
- **`agents`**: Kimi Code does not yet support plugin-provided sub-agents. This can be added once it does.

## Verification

- `bun run validate --coverage skip` passes (the validate script checks `.plugin/plugin.json` only and is unaffected by the new `.kimi-plugin/plugin.json`).
- Installed locally in Kimi Code from this branch: skills, commands, and the MCP server are discovered and work as expected.
