### PR TITLE
docs(ai-gateway): document provider key routing gotcha

### DIFF
--- a/skills/ai-gateway/SKILL.md
+++ b/skills/ai-gateway/SKILL.md
@@ -167,6 +167,20 @@ vercel env pull .env.local     # Provisions VERCEL_OIDC_TOKEN automatically
 3. No `AI_GATEWAY_API_KEY` or provider-specific keys (like `ANTHROPIC_API_KEY`) are needed
 4. On Vercel deployments, OIDC tokens are auto-refreshed — zero maintenance
 
+### Gateway Routing Gotcha: Remove Provider Keys
+
+When using AI SDK model strings such as `"anthropic/claude-haiku-4.5"` or `"openai/gpt-5.4"` with AI Gateway auto-routing, provider-specific API key env vars must be **absent**, not empty. If a Vercel project still has `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` from an older direct-provider integration, the AI SDK can choose direct-provider mode instead of routing through AI Gateway. An empty string value can still count as present and cause upstream errors such as `401 invalid x-api-key`.
+
+Remove stale provider keys from every environment and redeploy so warm function instances restart with the updated env:
+
+```bash
+vercel env rm ANTHROPIC_API_KEY production --yes
+vercel env rm ANTHROPIC_API_KEY preview --yes
+vercel env rm ANTHROPIC_API_KEY development --yes
+```
+
+Repeat for any other provider key that should no longer be used directly. Successful gateway-routed requests go through AI Gateway, not the upstream provider API directly.
+
 ### Local Development
 
 For local dev, the OIDC token from `vercel env pull` is valid for ~24 hours. When it expires:


### PR DESCRIPTION
## Summary

- Document that provider-specific API key env vars must be absent for AI Gateway auto-routing
- Add `vercel env rm` examples for removing stale provider keys across environments
- Mention redeploying so functions restart with the updated environment

## Why

Projects migrating from direct provider SDKs to AI Gateway can accidentally keep stale provider keys like `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` in Vercel env vars. When those keys are present, the AI SDK can choose direct-provider mode instead of routing through AI Gateway, even if the value is empty.

That makes failures confusing: the app appears to be configured for AI Gateway, but requests may still hit the upstream provider directly and fail with errors like `401 invalid x-api-key`. This docs note makes the migration path explicit: remove stale provider keys entirely, then redeploy.

## Verification

- `npx -y bun@latest run validate`

Closes #91