### PR TITLE
Connect: remove invalid scope example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.45.2",
+  "version": "0.45.1",
   "private": true,
   "bin": {
     "vercel-plugin": "src/cli/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-plugin",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "private": true,
   "bin": {
     "vercel-plugin": "src/cli/index.ts"

--- a/skills/vercel-connect/SKILL.md
+++ b/skills/vercel-connect/SKILL.md
@@ -307,7 +307,6 @@ connect_response = requests.post(
     headers={"Authorization": f"Bearer {os.environ['VERCEL_OIDC_TOKEN']}"},
     json={
         "subject": {"type": "app"},
-        "scopes": ["chat:write"],
     },
 )
 token = connect_response.json()["token"]


### PR DESCRIPTION
Minor fix. Providing scopes to `app` tokens for Slack is not supported.