### PR TITLE
fix: add mcp.json so Cursor registers the bundled MCP server

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vercel": {
+      "type": "http",
+      "url": "https://mcp.vercel.com"
+    }
+  }
+}


### PR DESCRIPTION
Cursor loads `mcp.json`, not `.mcp.json`, so the bundled MCP server never registers after install. Adds a Cursor-format `mcp.json` alongside the existing Claude Code one.

Verified by dropping `mcp.json` into the local Cursor plugin cache — `plugin-vercel-Vercel` showed up immediately (needsAuth).

Fixes #125