### PR TITLE
[cdn-caching] Describe PPR state by category, not raw proxy values

### DIFF
--- a/skills/cdn-caching/SKILL.md
+++ b/skills/cdn-caching/SKILL.md
@@ -130,15 +130,15 @@ Vercel caches at multiple layers between the visitor and your backend. A request
 
   A raw `MISS` with reason `draft_mode` / `prerender_bypass` / `crawler` is **displayed as `BYPASS`** (all usually expected). The three `stale_*` reasons separate a healthy time refresh (`stale_time`) from a broad-tag blast (`stale_tag`) from a failing regen (`stale_error`). Read `cacheReason` from `vercel logs` or the dashboard Logs "Reason" row — the `x-vercel-cache-reason` header is internal-only and not visible via `curl`.
 
-- **PPR state** (`ppr_state`) — for a Partial Prerendering route, _how much_ of the response was prerendered versus computed per request. Only set on `partial_prerender` serves; blank for plain `prerender` / `func` / `static` routes and for cases the proxy can't classify (cold shell miss, `BYPASS`). Three values:
+- **PPR state** (`ppr_state`) — for a Partial Prerendering route, _how much_ of the response was prerendered versus computed per request. Only set on `partial_prerender` serves; blank for plain `prerender` / `func` / `static` routes and for cases the proxy can't classify (cold shell miss, `BYPASS`). Three states:
 
-  | `ppr_state` | Shown as | Meaning                                                                             |
-  | ----------- | -------- | ----------------------------------------------------------------------------------- |
-  | `page`      | Static   | Fully prerendered — no postponed state, so the function is not invoked for the body |
-  | `shell`     | Partial  | Non-empty static shell from cache + a postponed hole the function resumes per request |
-  | `blocking`  | Dynamic  | Empty shell — the whole body is postponed and rendered by the function per request  |
+  | `ppr_state` | Meaning                                                                              |
+  | ----------- | ------------------------------------------------------------------------------------ |
+  | Static      | Fully prerendered — no postponed state, so the function is not invoked for the body   |
+  | Partial     | A static shell serves from cache + a postponed hole the function resumes per request  |
+  | Dynamic     | The whole body is postponed and rendered by the function per request                  |
 
-  A shell hit that still invokes the function is `shell` (Partial), _not_ a cache miss — the cached shell serves immediately while the function fills only the dynamic holes. Read `ppr_state` from `vercel logs` or the dashboard Logs panel, or aggregate with `vercel metrics vercel.request.count --group-by ppr_state`. Like `cacheReason`, the `x-vercel-ppr-state` header is internal-only and not visible via `curl`.
+  A **Partial** serve that still invokes the function is _not_ a cache miss — the cached shell serves immediately while the function fills only the dynamic holes. Read `ppr_state` from `vercel logs` or the dashboard Logs panel, or aggregate with `vercel metrics vercel.request.count --group-by ppr_state`. Like `cacheReason`, the `x-vercel-ppr-state` header is internal-only and not visible via `curl`.
 
 ## Investigating cache issues
 


### PR DESCRIPTION
### What

Follow-up to #128. Updates the **PPR state** table in the `cdn-caching` skill to drop the raw `ppr_state` proxy values (`page`, `shell`, `blocking`) and describe the three states purely by their user-facing category:

| `ppr_state` | Meaning |
|---|---|
| Static | Fully prerendered — no postponed state, so the function is not invoked for the body |
| Partial | A static shell serves from cache + a postponed hole the function resumes per request |
| Dynamic | The whole body is postponed and rendered by the function per request |

The surrounding prose is updated to match (a **Partial** serve, not a `shell` hit).

### Why

Users see PPR state categorized as (fully) static, partial, and (fully) dynamic. The raw `page`/`shell`/`blocking` values are internal proxy terms and don't belong in user-facing skill guidance.

### Notes

- Body-only change — the `ppr_state` field name, prompt signals, and retrieval entries from #128 are unchanged, so the generated manifests are untouched.
- `bun test` → 929 pass, 0 fail. `bun run validate` → passed (pre-existing workflow warning only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)